### PR TITLE
Add data/array/join

### DIFF
--- a/data/moxlib/functions/api/data/array/join.macro.mcfunction
+++ b/data/moxlib/functions/api/data/array/join.macro.mcfunction
@@ -1,0 +1,2 @@
+$data merge storage moxlib:api/data/array/join {target:$(target),separator:"$(separator)"}
+function moxlib:api/data/array/join

--- a/data/moxlib/functions/api/data/array/join.mcfunction
+++ b/data/moxlib/functions/api/data/array/join.mcfunction
@@ -1,0 +1,1 @@
+execute unless data storage moxlib:data/private {lock:true} run function moxlib:data/array/join/init

--- a/data/moxlib/functions/api/string/from_array.macro.mcfunction
+++ b/data/moxlib/functions/api/string/from_array.macro.mcfunction
@@ -1,2 +1,2 @@
-$data modify storage moxlib:api/string/from_array target set value $(target)
-function moxlib:api/string/from_array
+$function moxlib:api/data/array/join.macro {target:$(target),separator:""}
+data modify storage moxlib:api/string/from_array output set from storage moxlib:api/data/array/join output

--- a/data/moxlib/functions/api/string/from_array.mcfunction
+++ b/data/moxlib/functions/api/string/from_array.mcfunction
@@ -1,1 +1,1 @@
-execute unless data storage moxlib:string/private {lock:true} run function moxlib:string/from_array/init
+execute unless data storage moxlib:string/private {lock:true} run function moxlib:api/string/from_array.macro with storage moxlib:api/string/from_array

--- a/data/moxlib/functions/data/array/join/cleanup.mcfunction
+++ b/data/moxlib/functions/data/array/join/cleanup.mcfunction
@@ -1,0 +1,3 @@
+data modify storage moxlib:api/data/array/join output set from storage moxlib:data/array/join args.string
+data remove storage moxlib:api/data/array/join target
+data remove storage moxlib:api/data/array/join separator

--- a/data/moxlib/functions/data/array/join/init.mcfunction
+++ b/data/moxlib/functions/data/array/join/init.mcfunction
@@ -1,0 +1,7 @@
+function moxlib:data/common/setup
+function moxlib:data/array/join/setup
+
+execute if data storage moxlib:api/data/array/join target[0] run function moxlib:data/array/join/iterate with storage moxlib:data/array/join args
+
+function moxlib:data/array/join/cleanup
+function moxlib:data/common/cleanup

--- a/data/moxlib/functions/data/array/join/iterate.mcfunction
+++ b/data/moxlib/functions/data/array/join/iterate.mcfunction
@@ -1,0 +1,6 @@
+data remove storage moxlib:api/data/array/join target[0]
+
+$data modify storage moxlib:data/array/join args.string set value "$(string)$(separator)$(next)"
+
+data modify storage moxlib:data/array/join args.next set from storage moxlib:api/data/array/join target[0]
+execute if data storage moxlib:api/data/array/join target[] run function moxlib:data/array/join/iterate with storage moxlib:data/array/join args

--- a/data/moxlib/functions/data/array/join/setup.mcfunction
+++ b/data/moxlib/functions/data/array/join/setup.mcfunction
@@ -1,0 +1,4 @@
+data modify storage moxlib:data/array/join args.string set from storage moxlib:api/data/array/join target[0]
+data modify storage moxlib:data/array/join args.separator set from storage moxlib:api/data/array/join separator
+data remove storage moxlib:api/data/array/join target[0]
+data modify storage moxlib:data/array/join args.next set from storage moxlib:api/data/array/join target[0]

--- a/data/moxlib/functions/string/from_array/init.mcfunction
+++ b/data/moxlib/functions/string/from_array/init.mcfunction
@@ -1,8 +1,0 @@
-function moxlib:string/common/setup
-data modify storage moxlib:string/from_array concatenate.target set value ""
-
-function moxlib:string/from_array/iterate
-
-data modify storage moxlib:api/string/from_array output set from storage moxlib:string/from_array concatenate.target
-data remove storage moxlib:string/from_array concatenate
-function moxlib:string/common/cleanup

--- a/data/moxlib/functions/string/from_array/iterate.mcfunction
+++ b/data/moxlib/functions/string/from_array/iterate.mcfunction
@@ -1,8 +1,0 @@
-data modify storage moxlib:string/from_array concatenate.suffix set from storage moxlib:api/string/from_array target[0]
-
-function moxlib:api/string/concatenate.macro with storage moxlib:string/from_array concatenate
-
-data modify storage moxlib:string/from_array concatenate.target set from storage moxlib:api/string/concatenate output
-
-data remove storage moxlib:api/string/from_array target[0]
-execute if data storage moxlib:api/string/from_array target[] run function moxlib:string/from_array/iterate


### PR DESCRIPTION
Added an array join function, which takes `target` (array of strings) and `separator` (string) and returns the elements in `target`, concatenated together, separated by `separator`

Also changed `string/from_array` to call `data/array/join` with a separator of "".