### PR TITLE
Implement Call Function

### DIFF
--- a/data/moxlib/functions/api/call.macro.mcfunction
+++ b/data/moxlib/functions/api/call.macro.mcfunction
@@ -1,0 +1,1 @@
+$function $(target) $(args)

--- a/data/moxlib/functions/api/call.mcfunction
+++ b/data/moxlib/functions/api/call.mcfunction
@@ -1,0 +1,1 @@
+function moxlib:api/call.macro with storage moxlib:api/call


### PR DESCRIPTION
Added `moxlib:api/call`, which allows you to call functions dynamically, similar to `exec`.
It takes two arguments: `target` and `args`.