### PR TITLE
Refactor tests to make them more readable

### DIFF
--- a/data/moxlib/functions/z_spec/data/array/join.mcfunction
+++ b/data/moxlib/functions/z_spec/data/array/join.mcfunction
@@ -1,49 +1,58 @@
-data merge storage moxlib:api/data/array/join {target:["Hello", ", ", "world", "!"],separator:""}
-
-function moxlib:api/data/array/join
-
 data modify storage moxlib:test/it describes set value "An array joined with a blank separator"
-data modify storage moxlib:test/it expects set value "Hello, world!"
-data modify storage moxlib:test/it receives set from storage moxlib:api/data/array/join output
+
+  data merge storage moxlib:api/data/array/join {target:["Hello", ", ", "world", "!"],separator:""}
+
+  function moxlib:api/data/array/join
+
+  data modify storage moxlib:test/it expects set value "Hello, world!"
+  data modify storage moxlib:test/it receives set from storage moxlib:api/data/array/join output
 
 function moxlib:api/test/perform
 
-data merge storage moxlib:api/data/array/join {target:["a","b","c","d"],separator:","}
-
-function moxlib:api/data/array/join
 
 data modify storage moxlib:test/it describes set value "An array joined with a single character separator"
-data modify storage moxlib:test/it expects set value "a,b,c,d"
-data modify storage moxlib:test/it receives set from storage moxlib:api/data/array/join output
+
+  data merge storage moxlib:api/data/array/join {target:["a","b","c","d"],separator:","}
+
+  function moxlib:api/data/array/join
+
+  data modify storage moxlib:test/it expects set value "a,b,c,d"
+  data modify storage moxlib:test/it receives set from storage moxlib:api/data/array/join output
 
 function moxlib:api/test/perform
 
-data merge storage moxlib:api/data/array/join {target:["foo","bar","baz","qux"],separator:", "}
-
-function moxlib:api/data/array/join
 
 data modify storage moxlib:test/it describes set value "An array joined with a multi-character separator"
-data modify storage moxlib:test/it expects set value "foo, bar, baz, qux"
-data modify storage moxlib:test/it receives set from storage moxlib:api/data/array/join output
+
+  data merge storage moxlib:api/data/array/join {target:["foo","bar","baz","qux"],separator:", "}
+
+  function moxlib:api/data/array/join
+
+  data modify storage moxlib:test/it expects set value "foo, bar, baz, qux"
+  data modify storage moxlib:test/it receives set from storage moxlib:api/data/array/join output
 
 function moxlib:api/test/perform
 
-data merge storage moxlib:api/data/array/join {target:["42"],separator:":"}
-
-function moxlib:api/data/array/join
 
 data modify storage moxlib:test/it describes set value "An array with only one entry being joined"
-data modify storage moxlib:test/it expects set value "42"
-data modify storage moxlib:test/it receives set from storage moxlib:api/data/array/join output
+
+  data merge storage moxlib:api/data/array/join {target:["42"],separator:":"}
+
+  function moxlib:api/data/array/join
+
+  data modify storage moxlib:test/it expects set value "42"
+  data modify storage moxlib:test/it receives set from storage moxlib:api/data/array/join output
 
 function moxlib:api/test/perform
 
-data merge storage moxlib:api/data/array/join {target:[],separator:"!"}
-
-function moxlib:api/data/array/join
 
 data modify storage moxlib:test/it describes set value "An empty array being joined"
-data modify storage moxlib:test/it expects set value ""
-data modify storage moxlib:test/it receives set from storage moxlib:api/data/array/join output
+
+  data merge storage moxlib:api/data/array/join {target:[],separator:"!"}
+
+  function moxlib:api/data/array/join
+
+  data modify storage moxlib:test/it expects set value ""
+  data modify storage moxlib:test/it receives set from storage moxlib:api/data/array/join output
 
 function moxlib:api/test/perform

--- a/data/moxlib/functions/z_spec/data/array/pick.mcfunction
+++ b/data/moxlib/functions/z_spec/data/array/pick.mcfunction
@@ -1,9 +1,10 @@
-data modify storage moxlib:api/data/array/pick target set value [1,1,1,1]
-
-function moxlib:api/data/array/pick
-
 data modify storage moxlib:test/it describes set value "Successfully picking an item from an array"
-data modify storage moxlib:test/it expects set value 1
-data modify storage moxlib:test/it receives set from storage moxlib:api/data/array/pick output
+
+  data modify storage moxlib:api/data/array/pick target set value [1,1,1,1]
+
+  function moxlib:api/data/array/pick
+
+  data modify storage moxlib:test/it expects set value 1
+  data modify storage moxlib:test/it receives set from storage moxlib:api/data/array/pick output
 
 function moxlib:api/test/perform

--- a/data/moxlib/functions/z_spec/data/array/reverse.mcfunction
+++ b/data/moxlib/functions/z_spec/data/array/reverse.mcfunction
@@ -1,29 +1,34 @@
-data merge storage moxlib:api/data/array/reverse {target:["Hello", ", ", "world", "!"]}
-
-function moxlib:api/data/array/reverse
-
 data modify storage moxlib:test/it describes set value "An array reversed"
-data modify storage moxlib:test/it expects set value ["!", "world", ", ", "Hello"]
-data modify storage moxlib:test/it receives set from storage moxlib:api/data/array/reverse output
+
+  data merge storage moxlib:api/data/array/reverse {target:["Hello", ", ", "world", "!"]}
+
+  function moxlib:api/data/array/reverse
+
+  data modify storage moxlib:test/it expects set value ["!", "world", ", ", "Hello"]
+  data modify storage moxlib:test/it receives set from storage moxlib:api/data/array/reverse output
 
 function moxlib:api/test/perform
 
-data merge storage moxlib:api/data/array/reverse {target:["foo"]}
-
-function moxlib:api/data/array/reverse
 
 data modify storage moxlib:test/it describes set value "An array with one element reversed"
-data modify storage moxlib:test/it expects set value ["foo"]
-data modify storage moxlib:test/it receives set from storage moxlib:api/data/array/reverse output
+
+  data merge storage moxlib:api/data/array/reverse {target:["foo"]}
+
+  function moxlib:api/data/array/reverse
+
+  data modify storage moxlib:test/it expects set value ["foo"]
+  data modify storage moxlib:test/it receives set from storage moxlib:api/data/array/reverse output
 
 function moxlib:api/test/perform
 
-data merge storage moxlib:api/data/array/reverse {target:[]}
-
-function moxlib:api/data/array/reverse
 
 data modify storage moxlib:test/it describes set value "An array with no elements reversed"
-data modify storage moxlib:test/it expects set value []
-data modify storage moxlib:test/it receives set from storage moxlib:api/data/array/reverse output
+
+  data merge storage moxlib:api/data/array/reverse {target:[]}
+
+  function moxlib:api/data/array/reverse
+
+  data modify storage moxlib:test/it expects set value []
+  data modify storage moxlib:test/it receives set from storage moxlib:api/data/array/reverse output
 
 function moxlib:api/test/perform

--- a/data/moxlib/functions/z_spec/data/array/sample.mcfunction
+++ b/data/moxlib/functions/z_spec/data/array/sample.mcfunction
@@ -1,43 +1,50 @@
-data modify storage moxlib:api/data/array/sample target set value [1,1,1,1,1]
-data modify storage moxlib:api/data/array/sample amount set value 1
-
-function moxlib:api/data/array/sample
-
 data modify storage moxlib:test/it describes set value "Successfully sampling an item from an array"
-data modify storage moxlib:test/it expects set value [1]
-data modify storage moxlib:test/it receives set from storage moxlib:api/data/array/sample output
+
+  data modify storage moxlib:api/data/array/sample target set value [1,1,1,1,1]
+  data modify storage moxlib:api/data/array/sample amount set value 1
+
+  function moxlib:api/data/array/sample
+
+  data modify storage moxlib:test/it expects set value [1]
+  data modify storage moxlib:test/it receives set from storage moxlib:api/data/array/sample output
 
 function moxlib:api/test/perform
 
-data modify storage moxlib:api/data/array/sample target set value [42,42,42,42,42]
-data modify storage moxlib:api/data/array/sample amount set value 3
-
-function moxlib:api/data/array/sample
 
 data modify storage moxlib:test/it describes set value "Successfully sampling multiple items from an array"
-data modify storage moxlib:test/it expects set value [42,42,42]
-data modify storage moxlib:test/it receives set from storage moxlib:api/data/array/sample output
+
+  data modify storage moxlib:api/data/array/sample target set value [42,42,42,42,42]
+  data modify storage moxlib:api/data/array/sample amount set value 3
+
+  function moxlib:api/data/array/sample
+
+  data modify storage moxlib:test/it expects set value [42,42,42]
+  data modify storage moxlib:test/it receives set from storage moxlib:api/data/array/sample output
 
 function moxlib:api/test/perform
 
-data modify storage moxlib:api/data/array/sample target set value [69,69,69]
-data modify storage moxlib:api/data/array/sample amount set value 0
-
-function moxlib:api/data/array/sample
 
 data modify storage moxlib:test/it describes set value "Successfully sampling no items from an array"
-data modify storage moxlib:test/it expects set value []
-data modify storage moxlib:test/it receives set from storage moxlib:api/data/array/sample output
+
+  data modify storage moxlib:api/data/array/sample target set value [69,69,69]
+  data modify storage moxlib:api/data/array/sample amount set value 0
+
+  function moxlib:api/data/array/sample
+
+  data modify storage moxlib:test/it expects set value []
+  data modify storage moxlib:test/it receives set from storage moxlib:api/data/array/sample output
 
 function moxlib:api/test/perform
 
-data modify storage moxlib:api/data/array/sample target set value [17,17]
-data modify storage moxlib:api/data/array/sample amount set value 4
-
-function moxlib:api/data/array/sample
 
 data modify storage moxlib:test/it describes set value "Trying to sample too many items from an array"
-data modify storage moxlib:test/it expects set value [17,17]
-data modify storage moxlib:test/it receives set from storage moxlib:api/data/array/sample output
+
+  data modify storage moxlib:api/data/array/sample target set value [17,17]
+  data modify storage moxlib:api/data/array/sample amount set value 4
+
+  function moxlib:api/data/array/sample
+
+  data modify storage moxlib:test/it expects set value [17,17]
+  data modify storage moxlib:test/it receives set from storage moxlib:api/data/array/sample output
 
 function moxlib:api/test/perform

--- a/data/moxlib/functions/z_spec/data/array/slice.mcfunction
+++ b/data/moxlib/functions/z_spec/data/array/slice.mcfunction
@@ -1,67 +1,78 @@
-data modify storage moxlib:api/data/array/slice target set value [1,2,3,4,5,6,7,8,9]
-
-function moxlib:api/data/array/slice
-
 data modify storage moxlib:test/it describes set value "An array sliced with no start or end"
-data modify storage moxlib:test/it expects set value [1,2,3,4,5,6,7,8,9]
-data modify storage moxlib:test/it receives set from storage moxlib:api/data/array/slice output
+
+  data modify storage moxlib:api/data/array/slice target set value [1,2,3,4,5,6,7,8,9]
+
+  function moxlib:api/data/array/slice
+
+  data modify storage moxlib:test/it expects set value [1,2,3,4,5,6,7,8,9]
+  data modify storage moxlib:test/it receives set from storage moxlib:api/data/array/slice output
 
 function moxlib:api/test/perform
 
-data modify storage moxlib:api/data/array/slice target set value [1,2,3,4,5,6,7,8,9]
-data modify storage moxlib:api/data/array/slice start set value 2
-
-function moxlib:api/data/array/slice
 
 data modify storage moxlib:test/it describes set value "An array sliced with no end"
-data modify storage moxlib:test/it expects set value [3,4,5,6,7,8,9]
-data modify storage moxlib:test/it receives set from storage moxlib:api/data/array/slice output
+
+  data modify storage moxlib:api/data/array/slice target set value [1,2,3,4,5,6,7,8,9]
+  data modify storage moxlib:api/data/array/slice start set value 2
+
+  function moxlib:api/data/array/slice
+
+  data modify storage moxlib:test/it expects set value [3,4,5,6,7,8,9]
+  data modify storage moxlib:test/it receives set from storage moxlib:api/data/array/slice output
 
 function moxlib:api/test/perform
 
-data modify storage moxlib:api/data/array/slice target set value [1,2,3,4,5,6,7,8,9]
-data modify storage moxlib:api/data/array/slice end set value 7
-
-function moxlib:api/data/array/slice
 
 data modify storage moxlib:test/it describes set value "An array sliced with no start"
-data modify storage moxlib:test/it expects set value [1,2,3,4,5,6,7]
-data modify storage moxlib:test/it receives set from storage moxlib:api/data/array/slice output
+
+  data modify storage moxlib:api/data/array/slice target set value [1,2,3,4,5,6,7,8,9]
+  data modify storage moxlib:api/data/array/slice end set value 7
+
+  function moxlib:api/data/array/slice
+
+  data modify storage moxlib:test/it expects set value [1,2,3,4,5,6,7]
+  data modify storage moxlib:test/it receives set from storage moxlib:api/data/array/slice output
 
 function moxlib:api/test/perform
 
-data modify storage moxlib:api/data/array/slice target set value [1,2,3,4,5,6,7,8,9]
-data modify storage moxlib:api/data/array/slice start set value 4
-data modify storage moxlib:api/data/array/slice end set value 7
-
-function moxlib:api/data/array/slice
 
 data modify storage moxlib:test/it describes set value "A slice operation"
-data modify storage moxlib:test/it expects set value [5,6,7]
-data modify storage moxlib:test/it receives set from storage moxlib:api/data/array/slice output
+
+  data modify storage moxlib:api/data/array/slice target set value [1,2,3,4,5,6,7,8,9]
+  data modify storage moxlib:api/data/array/slice start set value 4
+  data modify storage moxlib:api/data/array/slice end set value 7
+
+  function moxlib:api/data/array/slice
+
+  data modify storage moxlib:test/it expects set value [5,6,7]
+  data modify storage moxlib:test/it receives set from storage moxlib:api/data/array/slice output
 
 function moxlib:api/test/perform
 
-data modify storage moxlib:api/data/array/slice target set value [1,2,3,4,5,6,7,8,9]
-data modify storage moxlib:api/data/array/slice start set value 4
-data modify storage moxlib:api/data/array/slice end set value 4
-
-function moxlib:api/data/array/slice
 
 data modify storage moxlib:test/it describes set value "A slice operation with zero magnitude"
-data modify storage moxlib:test/it expects set value []
-data modify storage moxlib:test/it receives set from storage moxlib:api/data/array/slice output
+
+  data modify storage moxlib:api/data/array/slice target set value [1,2,3,4,5,6,7,8,9]
+  data modify storage moxlib:api/data/array/slice start set value 4
+  data modify storage moxlib:api/data/array/slice end set value 4
+
+  function moxlib:api/data/array/slice
+
+  data modify storage moxlib:test/it expects set value []
+  data modify storage moxlib:test/it receives set from storage moxlib:api/data/array/slice output
 
 function moxlib:api/test/perform
 
-data modify storage moxlib:api/data/array/slice target set value [1,2,3,4,5,6,7,8,9]
-data modify storage moxlib:api/data/array/slice start set value 4
-data modify storage moxlib:api/data/array/slice end set value 2
-
-function moxlib:api/data/array/slice
 
 data modify storage moxlib:test/it describes set value "A slice operation with the end less than the start"
-data modify storage moxlib:test/it expects set value {success:0b,error:"End cannot be less than start"}
-data modify storage moxlib:test/it receives set from storage moxlib:api/data/array/slice {}
+
+  data modify storage moxlib:api/data/array/slice target set value [1,2,3,4,5,6,7,8,9]
+  data modify storage moxlib:api/data/array/slice start set value 4
+  data modify storage moxlib:api/data/array/slice end set value 2
+
+  function moxlib:api/data/array/slice
+
+  data modify storage moxlib:test/it expects set value {success:0b,error:"End cannot be less than start"}
+  data modify storage moxlib:test/it receives set from storage moxlib:api/data/array/slice {}
 
 function moxlib:api/test/perform

--- a/data/moxlib/functions/z_spec/data/collect.mcfunction
+++ b/data/moxlib/functions/z_spec/data/collect.mcfunction
@@ -1,21 +1,24 @@
-data modify storage moxlib:api/data/collect target set value [{collect:true,data:"foo"},{collect:false,data:"bar"},{collect:false,data:"baz"},{collect:true,data:"qux"}]
-data modify storage moxlib:api/data/collect key set value {collect:true}
-
-function moxlib:api/data/collect
-
 data modify storage moxlib:test/it describes set value "Correctly collecting elements"
-data modify storage moxlib:test/it expects set value [{collect:true,data:"foo"},{collect:true,data:"qux"}]
-data modify storage moxlib:test/it receives set from storage moxlib:api/data/collect output.match
+
+  data modify storage moxlib:api/data/collect target set value [{collect:true,data:"foo"},{collect:false,data:"bar"},{collect:false,data:"baz"},{collect:true,data:"qux"}]
+  data modify storage moxlib:api/data/collect key set value {collect:true}
+
+  function moxlib:api/data/collect
+
+  data modify storage moxlib:test/it expects set value [{collect:true,data:"foo"},{collect:true,data:"qux"}]
+  data modify storage moxlib:test/it receives set from storage moxlib:api/data/collect output.match
 
 function moxlib:api/test/perform
 
-data modify storage moxlib:api/data/collect target set value [{collect:true,data:"foo"},{collect:false,data:"bar"},{collect:false,data:"baz"},{collect:true,data:"qux"}]
-data modify storage moxlib:api/data/collect key set value {collect:true}
-
-function moxlib:api/data/collect
 
 data modify storage moxlib:test/it describes set value "Correctly not collecting elements"
-data modify storage moxlib:test/it expects set value [{collect:false,data:"bar"},{collect:false,data:"baz"}]
-data modify storage moxlib:test/it receives set from storage moxlib:api/data/collect output.remain
+
+  data modify storage moxlib:api/data/collect target set value [{collect:true,data:"foo"},{collect:false,data:"bar"},{collect:false,data:"baz"},{collect:true,data:"qux"}]
+  data modify storage moxlib:api/data/collect key set value {collect:true}
+
+  function moxlib:api/data/collect
+
+  data modify storage moxlib:test/it expects set value [{collect:false,data:"bar"},{collect:false,data:"baz"}]
+  data modify storage moxlib:test/it receives set from storage moxlib:api/data/collect output.remain
 
 function moxlib:api/test/perform

--- a/data/moxlib/functions/z_spec/data/compare_different.mcfunction
+++ b/data/moxlib/functions/z_spec/data/compare_different.mcfunction
@@ -1,10 +1,11 @@
-data modify storage moxlib:api/data/compare target set value {id:4s}
-data modify storage moxlib:api/data/compare key set value {id:3s}
-
-function moxlib:api/data/compare
-
 data modify storage moxlib:test/it describes set value "Compare different"
-data modify storage moxlib:test/it expects set value {result:false}
-data modify storage moxlib:test/it receives.result set from storage moxlib:api/data/compare output
+
+  data modify storage moxlib:api/data/compare target set value {id:4s}
+  data modify storage moxlib:api/data/compare key set value {id:3s}
+
+  function moxlib:api/data/compare
+
+  data modify storage moxlib:test/it expects set value {result:false}
+  data modify storage moxlib:test/it receives.result set from storage moxlib:api/data/compare output
 
 function moxlib:api/test/perform

--- a/data/moxlib/functions/z_spec/data/compare_same.mcfunction
+++ b/data/moxlib/functions/z_spec/data/compare_same.mcfunction
@@ -1,10 +1,11 @@
-data modify storage moxlib:api/data/compare target set value {id:3s}
-data modify storage moxlib:api/data/compare key set value {id:3s}
-
-function moxlib:api/data/compare
-
 data modify storage moxlib:test/it describes set value "Compare same"
-data modify storage moxlib:test/it expects set value {result:true}
-data modify storage moxlib:test/it receives.result set from storage moxlib:api/data/compare output
+
+  data modify storage moxlib:api/data/compare target set value {id:3s}
+  data modify storage moxlib:api/data/compare key set value {id:3s}
+
+  function moxlib:api/data/compare
+
+  data modify storage moxlib:test/it expects set value {result:true}
+  data modify storage moxlib:test/it receives.result set from storage moxlib:api/data/compare output
 
 function moxlib:api/test/perform

--- a/data/moxlib/functions/z_spec/data/get.mcfunction
+++ b/data/moxlib/functions/z_spec/data/get.mcfunction
@@ -1,10 +1,11 @@
-data modify storage moxlib:api/data/get target set value [{id:1s,data:"test"},{id:2s,data:"test"},{id:3s,data:"test"},{id:4s,data:"test"}]
-data modify storage moxlib:api/data/get key set value {id:3s}
-
-function moxlib:api/data/get
-
 data modify storage moxlib:test/it describes set value "The get function"
-data modify storage moxlib:test/it expects set value {id:3s,data:"test"}
-data modify storage moxlib:test/it receives set from storage moxlib:api/data/get output
+
+  data modify storage moxlib:api/data/get target set value [{id:1s,data:"test"},{id:2s,data:"test"},{id:3s,data:"test"},{id:4s,data:"test"}]
+  data modify storage moxlib:api/data/get key set value {id:3s}
+
+  function moxlib:api/data/get
+
+  data modify storage moxlib:test/it expects set value {id:3s,data:"test"}
+  data modify storage moxlib:test/it receives set from storage moxlib:api/data/get output
 
 function moxlib:api/test/perform

--- a/data/moxlib/functions/z_spec/data/includes.mcfunction
+++ b/data/moxlib/functions/z_spec/data/includes.mcfunction
@@ -1,10 +1,11 @@
-data modify storage moxlib:api/data/get target set value [{id:1s},{id:2s},{id:3s},{id:4s}]
-data modify storage moxlib:api/data/get key set value {id:3s}
-
-function moxlib:api/data/get
-
 data modify storage moxlib:test/it describes set value "Check includes"
-data modify storage moxlib:test/it expects set value {success:true}
-data modify storage moxlib:test/it receives.success set from storage moxlib:api/data/get success
+
+  data modify storage moxlib:api/data/get target set value [{id:1s},{id:2s},{id:3s},{id:4s}]
+  data modify storage moxlib:api/data/get key set value {id:3s}
+
+  function moxlib:api/data/get
+
+  data modify storage moxlib:test/it expects set value {success:true}
+  data modify storage moxlib:test/it receives.success set from storage moxlib:api/data/get success
 
 function moxlib:api/test/perform

--- a/data/moxlib/functions/z_spec/data/legacy/collect.mcfunction
+++ b/data/moxlib/functions/z_spec/data/legacy/collect.mcfunction
@@ -1,21 +1,24 @@
-data modify storage moxlib:api/data/legacy/collect target set value [{collect:true,data:"foo"},{collect:false,data:"bar"},{collect:false,data:"baz"},{collect:true,data:"qux"}]
-data modify storage moxlib:api/data/legacy/collect key set value {collect:true}
-
-function moxlib:api/data/legacy/collect
-
 data modify storage moxlib:test/it describes set value "Correctly collecting elements"
-data modify storage moxlib:test/it expects set value [{collect:true,data:"foo"},{collect:true,data:"qux"}]
-data modify storage moxlib:test/it receives set from storage moxlib:api/data/legacy/collect output.match
+
+  data modify storage moxlib:api/data/legacy/collect target set value [{collect:true,data:"foo"},{collect:false,data:"bar"},{collect:false,data:"baz"},{collect:true,data:"qux"}]
+  data modify storage moxlib:api/data/legacy/collect key set value {collect:true}
+
+  function moxlib:api/data/legacy/collect
+
+  data modify storage moxlib:test/it expects set value [{collect:true,data:"foo"},{collect:true,data:"qux"}]
+  data modify storage moxlib:test/it receives set from storage moxlib:api/data/legacy/collect output.match
 
 function moxlib:api/test/perform
 
-data modify storage moxlib:api/data/legacy/collect target set value [{collect:true,data:"foo"},{collect:false,data:"bar"},{collect:false,data:"baz"},{collect:true,data:"qux"}]
-data modify storage moxlib:api/data/legacy/collect key set value {collect:true}
-
-function moxlib:api/data/legacy/collect
 
 data modify storage moxlib:test/it describes set value "Correctly not collecting elements"
-data modify storage moxlib:test/it expects set value [{collect:false,data:"bar"},{collect:false,data:"baz"}]
-data modify storage moxlib:test/it receives set from storage moxlib:api/data/legacy/collect output.remain
+
+  data modify storage moxlib:api/data/legacy/collect target set value [{collect:true,data:"foo"},{collect:false,data:"bar"},{collect:false,data:"baz"},{collect:true,data:"qux"}]
+  data modify storage moxlib:api/data/legacy/collect key set value {collect:true}
+
+  function moxlib:api/data/legacy/collect
+
+  data modify storage moxlib:test/it expects set value [{collect:false,data:"bar"},{collect:false,data:"baz"}]
+  data modify storage moxlib:test/it receives set from storage moxlib:api/data/legacy/collect output.remain
 
 function moxlib:api/test/perform

--- a/data/moxlib/functions/z_spec/data/legacy/compare_different.mcfunction
+++ b/data/moxlib/functions/z_spec/data/legacy/compare_different.mcfunction
@@ -1,10 +1,11 @@
-data modify storage moxlib:api/data/legacy/compare target set value {id:4s}
-data modify storage moxlib:api/data/legacy/compare key set value {id:3s}
-
-function moxlib:api/data/legacy/compare
-
 data modify storage moxlib:test/it describes set value "Compare different"
-data modify storage moxlib:test/it expects set value {result:false}
-data modify storage moxlib:test/it receives.result set from storage moxlib:api/data/legacy/compare output
+
+  data modify storage moxlib:api/data/legacy/compare target set value {id:4s}
+  data modify storage moxlib:api/data/legacy/compare key set value {id:3s}
+
+  function moxlib:api/data/legacy/compare
+
+  data modify storage moxlib:test/it expects set value {result:false}
+  data modify storage moxlib:test/it receives.result set from storage moxlib:api/data/legacy/compare output
 
 function moxlib:api/test/perform

--- a/data/moxlib/functions/z_spec/data/legacy/compare_same.mcfunction
+++ b/data/moxlib/functions/z_spec/data/legacy/compare_same.mcfunction
@@ -1,10 +1,11 @@
-data modify storage moxlib:api/data/legacy/compare target set value {id:3s}
-data modify storage moxlib:api/data/legacy/compare key set value {id:3s}
-
-function moxlib:api/data/legacy/compare
-
 data modify storage moxlib:test/it describes set value "Compare same"
-data modify storage moxlib:test/it expects set value {result:true}
-data modify storage moxlib:test/it receives.result set from storage moxlib:api/data/legacy/compare output
+
+  data modify storage moxlib:api/data/legacy/compare target set value {id:3s}
+  data modify storage moxlib:api/data/legacy/compare key set value {id:3s}
+
+  function moxlib:api/data/legacy/compare
+
+  data modify storage moxlib:test/it expects set value {result:true}
+  data modify storage moxlib:test/it receives.result set from storage moxlib:api/data/legacy/compare output
 
 function moxlib:api/test/perform

--- a/data/moxlib/functions/z_spec/data/legacy/get.mcfunction
+++ b/data/moxlib/functions/z_spec/data/legacy/get.mcfunction
@@ -1,10 +1,11 @@
-data modify storage moxlib:api/data/legacy/get target set value [{id:1s,data:"test"},{id:2s,data:"test"},{id:3s,data:"test"},{id:4s,data:"test"}]
-data modify storage moxlib:api/data/legacy/get key set value {id:3s}
-
-function moxlib:api/data/legacy/get
-
 data modify storage moxlib:test/it describes set value "The get function"
-data modify storage moxlib:test/it expects set value {id:3s,data:"test"}
-data modify storage moxlib:test/it receives set from storage moxlib:api/data/legacy/get output
+
+  data modify storage moxlib:api/data/legacy/get target set value [{id:1s,data:"test"},{id:2s,data:"test"},{id:3s,data:"test"},{id:4s,data:"test"}]
+  data modify storage moxlib:api/data/legacy/get key set value {id:3s}
+
+  function moxlib:api/data/legacy/get
+
+  data modify storage moxlib:test/it expects set value {id:3s,data:"test"}
+  data modify storage moxlib:test/it receives set from storage moxlib:api/data/legacy/get output
 
 function moxlib:api/test/perform

--- a/data/moxlib/functions/z_spec/data/legacy/includes.mcfunction
+++ b/data/moxlib/functions/z_spec/data/legacy/includes.mcfunction
@@ -1,10 +1,11 @@
-data modify storage moxlib:api/data/legacy/get target set value [{id:1s},{id:2s},{id:3s},{id:4s}]
-data modify storage moxlib:api/data/legacy/get key set value {id:3s}
-
-function moxlib:api/data/legacy/get
-
 data modify storage moxlib:test/it describes set value "Check includes"
-data modify storage moxlib:test/it expects set value {success:true}
-data modify storage moxlib:test/it receives.success set from storage moxlib:api/data/legacy/get success
+
+  data modify storage moxlib:api/data/legacy/get target set value [{id:1s},{id:2s},{id:3s},{id:4s}]
+  data modify storage moxlib:api/data/legacy/get key set value {id:3s}
+
+  function moxlib:api/data/legacy/get
+
+  data modify storage moxlib:test/it expects set value {success:true}
+  data modify storage moxlib:test/it receives.success set from storage moxlib:api/data/legacy/get success
 
 function moxlib:api/test/perform

--- a/data/moxlib/functions/z_spec/data/legacy/not_includes.mcfunction
+++ b/data/moxlib/functions/z_spec/data/legacy/not_includes.mcfunction
@@ -1,10 +1,11 @@
-data modify storage moxlib:api/data/legacy/get target set value [{id:1s},{id:2s},{id:3s},{id:4s}]
-data modify storage moxlib:api/data/legacy/get key set value {id:5s}
-
-function moxlib:api/data/legacy/get
-
 data modify storage moxlib:test/it describes set value "Not includes"
-data modify storage moxlib:test/it expects set value {success:false}
-data modify storage moxlib:test/it receives.success set from storage moxlib:api/data/legacy/get success
+
+  data modify storage moxlib:api/data/legacy/get target set value [{id:1s},{id:2s},{id:3s},{id:4s}]
+  data modify storage moxlib:api/data/legacy/get key set value {id:5s}
+
+  function moxlib:api/data/legacy/get
+
+  data modify storage moxlib:test/it expects set value {success:false}
+  data modify storage moxlib:test/it receives.success set from storage moxlib:api/data/legacy/get success
 
 function moxlib:api/test/perform

--- a/data/moxlib/functions/z_spec/data/legacy/set.mcfunction
+++ b/data/moxlib/functions/z_spec/data/legacy/set.mcfunction
@@ -1,16 +1,17 @@
-data modify storage moxlib:api/data/legacy/set target set value [{id:1s,data:"test"},{id:2s,data:"test"},{id:3s,hello:"test"},{id:4s,data:"test"}]
-data modify storage moxlib:api/data/legacy/set key set value {id:3s}
-data modify storage moxlib:api/data/legacy/set data set value {hello:"hi"}
-
-function moxlib:api/data/legacy/set
-
-data modify storage moxlib:api/data/legacy/get target set from storage moxlib:api/data/legacy/set output
-data modify storage moxlib:api/data/legacy/get key set value {id:3s}
-
-function moxlib:api/data/legacy/get
-
 data modify storage moxlib:test/it describes set value "The set function"
-data modify storage moxlib:test/it expects set value {id:3s,hello:"hi"}
-data modify storage moxlib:test/it receives set from storage moxlib:api/data/legacy/get output
+
+  data modify storage moxlib:api/data/legacy/set target set value [{id:1s,data:"test"},{id:2s,data:"test"},{id:3s,hello:"test"},{id:4s,data:"test"}]
+  data modify storage moxlib:api/data/legacy/set key set value {id:3s}
+  data modify storage moxlib:api/data/legacy/set data set value {hello:"hi"}
+
+  function moxlib:api/data/legacy/set
+
+  data modify storage moxlib:api/data/legacy/get target set from storage moxlib:api/data/legacy/set output
+  data modify storage moxlib:api/data/legacy/get key set value {id:3s}
+
+  function moxlib:api/data/legacy/get
+
+  data modify storage moxlib:test/it expects set value {id:3s,hello:"hi"}
+  data modify storage moxlib:test/it receives set from storage moxlib:api/data/legacy/get output
 
 function moxlib:api/test/perform

--- a/data/moxlib/functions/z_spec/data/not_includes.mcfunction
+++ b/data/moxlib/functions/z_spec/data/not_includes.mcfunction
@@ -1,10 +1,11 @@
-data modify storage moxlib:api/data/get target set value [{id:1s},{id:2s},{id:3s},{id:4s}]
-data modify storage moxlib:api/data/get key set value {id:5s}
-
-function moxlib:api/data/get
-
 data modify storage moxlib:test/it describes set value "Not includes"
-data modify storage moxlib:test/it expects set value {success:false}
-data modify storage moxlib:test/it receives.success set from storage moxlib:api/data/get success
+
+  data modify storage moxlib:api/data/get target set value [{id:1s},{id:2s},{id:3s},{id:4s}]
+  data modify storage moxlib:api/data/get key set value {id:5s}
+
+  function moxlib:api/data/get
+
+  data modify storage moxlib:test/it expects set value {success:false}
+  data modify storage moxlib:test/it receives.success set from storage moxlib:api/data/get success
 
 function moxlib:api/test/perform

--- a/data/moxlib/functions/z_spec/data/paginate.mcfunction
+++ b/data/moxlib/functions/z_spec/data/paginate.mcfunction
@@ -1,35 +1,40 @@
-data modify storage moxlib:api/data/paginate target set value [1,2,3,4,5,6,7,8,9]
-data modify storage moxlib:api/data/paginate count set value 3
-data modify storage moxlib:api/data/paginate page set value 2
-
-function moxlib:api/data/paginate
-
 data modify storage moxlib:test/it describes set value "Paginating an array"
-data modify storage moxlib:test/it expects set value [4,5,6]
-data modify storage moxlib:test/it receives set from storage moxlib:api/data/paginate output
+
+  data modify storage moxlib:api/data/paginate target set value [1,2,3,4,5,6,7,8,9]
+  data modify storage moxlib:api/data/paginate count set value 3
+  data modify storage moxlib:api/data/paginate page set value 2
+
+  function moxlib:api/data/paginate
+
+  data modify storage moxlib:test/it expects set value [4,5,6]
+  data modify storage moxlib:test/it receives set from storage moxlib:api/data/paginate output
 
 function moxlib:api/test/perform
 
-data modify storage moxlib:api/data/paginate target set value [1,2,3,4,5,6,7,8]
-data modify storage moxlib:api/data/paginate count set value 3
-data modify storage moxlib:api/data/paginate page set value 3
-
-function moxlib:api/data/paginate
 
 data modify storage moxlib:test/it describes set value "Paginating an array with not enough elements"
-data modify storage moxlib:test/it expects set value [7,8]
-data modify storage moxlib:test/it receives set from storage moxlib:api/data/paginate output
+
+  data modify storage moxlib:api/data/paginate target set value [1,2,3,4,5,6,7,8]
+  data modify storage moxlib:api/data/paginate count set value 3
+  data modify storage moxlib:api/data/paginate page set value 3
+
+  function moxlib:api/data/paginate
+
+  data modify storage moxlib:test/it expects set value [7,8]
+  data modify storage moxlib:test/it receives set from storage moxlib:api/data/paginate output
 
 function moxlib:api/test/perform
 
-data modify storage moxlib:api/data/paginate target set value []
-data modify storage moxlib:api/data/paginate count set value 2
-data modify storage moxlib:api/data/paginate page set value 1
-
-function moxlib:api/data/paginate
 
 data modify storage moxlib:test/it describes set value "Paginating an array with no elements"
-data modify storage moxlib:test/it expects set value []
-data modify storage moxlib:test/it receives set from storage moxlib:api/data/paginate output
+
+  data modify storage moxlib:api/data/paginate target set value []
+  data modify storage moxlib:api/data/paginate count set value 2
+  data modify storage moxlib:api/data/paginate page set value 1
+
+  function moxlib:api/data/paginate
+
+  data modify storage moxlib:test/it expects set value []
+  data modify storage moxlib:test/it receives set from storage moxlib:api/data/paginate output
 
 function moxlib:api/test/perform

--- a/data/moxlib/functions/z_spec/data/set.mcfunction
+++ b/data/moxlib/functions/z_spec/data/set.mcfunction
@@ -1,16 +1,17 @@
-data modify storage moxlib:api/data/set target set value [{id:1s,data:"test"},{id:2s,data:"test"},{id:3s,hello:"test"},{id:4s,data:"test"}]
-data modify storage moxlib:api/data/set key set value {id:3s}
-data modify storage moxlib:api/data/set data set value {hello:"hi"}
-
-function moxlib:api/data/set
-
-data modify storage moxlib:api/data/get target set from storage moxlib:api/data/set output
-data modify storage moxlib:api/data/get key set value {id:3s}
-
-function moxlib:api/data/get
-
 data modify storage moxlib:test/it describes set value "The set function"
-data modify storage moxlib:test/it expects set value {id:3s,hello:"hi"}
-data modify storage moxlib:test/it receives set from storage moxlib:api/data/get output
+
+  data modify storage moxlib:api/data/set target set value [{id:1s,data:"test"},{id:2s,data:"test"},{id:3s,hello:"test"},{id:4s,data:"test"}]
+  data modify storage moxlib:api/data/set key set value {id:3s}
+  data modify storage moxlib:api/data/set data set value {hello:"hi"}
+
+  function moxlib:api/data/set
+
+  data modify storage moxlib:api/data/get target set from storage moxlib:api/data/set output
+  data modify storage moxlib:api/data/get key set value {id:3s}
+
+  function moxlib:api/data/get
+
+  data modify storage moxlib:test/it expects set value {id:3s,hello:"hi"}
+  data modify storage moxlib:test/it receives set from storage moxlib:api/data/get output
 
 function moxlib:api/test/perform

--- a/data/moxlib/functions/z_spec/helpers/data/type/array.mcfunction
+++ b/data/moxlib/functions/z_spec/helpers/data/type/array.mcfunction
@@ -1,8 +1,9 @@
-data modify storage moxlib:api/helpers/data/type target set value ["a","b"]
-function moxlib:api/helpers/data/type
-
 data modify storage moxlib:test/it describes set value "Detects array type"
-data modify storage moxlib:test/it expects set value "array"
-data modify storage moxlib:test/it receives set from storage moxlib:api/helpers/data/type output
+
+  data modify storage moxlib:api/helpers/data/type target set value ["a","b"]
+  function moxlib:api/helpers/data/type
+
+  data modify storage moxlib:test/it expects set value "array"
+  data modify storage moxlib:test/it receives set from storage moxlib:api/helpers/data/type output
 
 function moxlib:api/test/perform

--- a/data/moxlib/functions/z_spec/helpers/data/type/byte.mcfunction
+++ b/data/moxlib/functions/z_spec/helpers/data/type/byte.mcfunction
@@ -1,8 +1,9 @@
-data modify storage moxlib:api/helpers/data/type target set value 1b
-function moxlib:api/helpers/data/type
-
 data modify storage moxlib:test/it describes set value "Detects byte type"
-data modify storage moxlib:test/it expects set value "byte"
-data modify storage moxlib:test/it receives set from storage moxlib:api/helpers/data/type output
+
+  data modify storage moxlib:api/helpers/data/type target set value 1b
+  function moxlib:api/helpers/data/type
+
+  data modify storage moxlib:test/it expects set value "byte"
+  data modify storage moxlib:test/it receives set from storage moxlib:api/helpers/data/type output
 
 function moxlib:api/test/perform

--- a/data/moxlib/functions/z_spec/helpers/data/type/double.mcfunction
+++ b/data/moxlib/functions/z_spec/helpers/data/type/double.mcfunction
@@ -1,8 +1,9 @@
-data modify storage moxlib:api/helpers/data/type target set value 1d
-function moxlib:api/helpers/data/type
-
 data modify storage moxlib:test/it describes set value "Detects double type"
-data modify storage moxlib:test/it expects set value "double"
-data modify storage moxlib:test/it receives set from storage moxlib:api/helpers/data/type output
+
+  data modify storage moxlib:api/helpers/data/type target set value 1d
+  function moxlib:api/helpers/data/type
+
+  data modify storage moxlib:test/it expects set value "double"
+  data modify storage moxlib:test/it receives set from storage moxlib:api/helpers/data/type output
 
 function moxlib:api/test/perform

--- a/data/moxlib/functions/z_spec/helpers/data/type/float.mcfunction
+++ b/data/moxlib/functions/z_spec/helpers/data/type/float.mcfunction
@@ -1,8 +1,9 @@
-data modify storage moxlib:api/helpers/data/type target set value 1f
-function moxlib:api/helpers/data/type
-
 data modify storage moxlib:test/it describes set value "Detects float type"
-data modify storage moxlib:test/it expects set value "float"
-data modify storage moxlib:test/it receives set from storage moxlib:api/helpers/data/type output
+
+  data modify storage moxlib:api/helpers/data/type target set value 1f
+  function moxlib:api/helpers/data/type
+
+  data modify storage moxlib:test/it expects set value "float"
+  data modify storage moxlib:test/it receives set from storage moxlib:api/helpers/data/type output
 
 function moxlib:api/test/perform

--- a/data/moxlib/functions/z_spec/helpers/data/type/int.mcfunction
+++ b/data/moxlib/functions/z_spec/helpers/data/type/int.mcfunction
@@ -1,8 +1,9 @@
-data modify storage moxlib:api/helpers/data/type target set value 1
-function moxlib:api/helpers/data/type
-
 data modify storage moxlib:test/it describes set value "Detects int type"
-data modify storage moxlib:test/it expects set value "integer"
-data modify storage moxlib:test/it receives set from storage moxlib:api/helpers/data/type output
+
+  data modify storage moxlib:api/helpers/data/type target set value 1
+  function moxlib:api/helpers/data/type
+
+  data modify storage moxlib:test/it expects set value "integer"
+  data modify storage moxlib:test/it receives set from storage moxlib:api/helpers/data/type output
 
 function moxlib:api/test/perform

--- a/data/moxlib/functions/z_spec/helpers/data/type/invalid_json.mcfunction
+++ b/data/moxlib/functions/z_spec/helpers/data/type/invalid_json.mcfunction
@@ -1,8 +1,9 @@
-data modify storage moxlib:api/helpers/data/type target set value '{"tex":"__test"}'
-function moxlib:api/helpers/data/type
-
 data modify storage moxlib:test/it describes set value "Detects invalid json"
-data modify storage moxlib:test/it expects set value "string"
-data modify storage moxlib:test/it receives set from storage moxlib:api/helpers/data/type output
+
+  data modify storage moxlib:api/helpers/data/type target set value '{"tex":"__test"}'
+  function moxlib:api/helpers/data/type
+
+  data modify storage moxlib:test/it expects set value "string"
+  data modify storage moxlib:test/it receives set from storage moxlib:api/helpers/data/type output
 
 function moxlib:api/test/perform

--- a/data/moxlib/functions/z_spec/helpers/data/type/json.mcfunction
+++ b/data/moxlib/functions/z_spec/helpers/data/type/json.mcfunction
@@ -1,8 +1,9 @@
-data modify storage moxlib:api/helpers/data/type target set value '{"text":"__test"}'
-function moxlib:api/helpers/data/type
-
 data modify storage moxlib:test/it describes set value "Detects json type"
-data modify storage moxlib:test/it expects set value "json"
-data modify storage moxlib:test/it receives set from storage moxlib:api/helpers/data/type output
+
+  data modify storage moxlib:api/helpers/data/type target set value '{"text":"__test"}'
+  function moxlib:api/helpers/data/type
+
+  data modify storage moxlib:test/it expects set value "json"
+  data modify storage moxlib:test/it receives set from storage moxlib:api/helpers/data/type output
 
 function moxlib:api/test/perform

--- a/data/moxlib/functions/z_spec/helpers/data/type/long.mcfunction
+++ b/data/moxlib/functions/z_spec/helpers/data/type/long.mcfunction
@@ -1,8 +1,9 @@
-data modify storage moxlib:api/helpers/data/type target set value 1l
-function moxlib:api/helpers/data/type
-
 data modify storage moxlib:test/it describes set value "Detects long type"
-data modify storage moxlib:test/it expects set value "long"
-data modify storage moxlib:test/it receives set from storage moxlib:api/helpers/data/type output
+
+  data modify storage moxlib:api/helpers/data/type target set value 1l
+  function moxlib:api/helpers/data/type
+
+  data modify storage moxlib:test/it expects set value "long"
+  data modify storage moxlib:test/it receives set from storage moxlib:api/helpers/data/type output
 
 function moxlib:api/test/perform

--- a/data/moxlib/functions/z_spec/helpers/data/type/object.mcfunction
+++ b/data/moxlib/functions/z_spec/helpers/data/type/object.mcfunction
@@ -1,8 +1,9 @@
-data modify storage moxlib:api/helpers/data/type target set value {a:1,b:2}
-function moxlib:api/helpers/data/type
-
 data modify storage moxlib:test/it describes set value "Detects object type"
-data modify storage moxlib:test/it expects set value "object"
-data modify storage moxlib:test/it receives set from storage moxlib:api/helpers/data/type output
+
+  data modify storage moxlib:api/helpers/data/type target set value {a:1,b:2}
+  function moxlib:api/helpers/data/type
+
+  data modify storage moxlib:test/it expects set value "object"
+  data modify storage moxlib:test/it receives set from storage moxlib:api/helpers/data/type output
 
 function moxlib:api/test/perform

--- a/data/moxlib/functions/z_spec/helpers/data/type/short.mcfunction
+++ b/data/moxlib/functions/z_spec/helpers/data/type/short.mcfunction
@@ -1,8 +1,9 @@
-data modify storage moxlib:api/helpers/data/type target set value 1s
-function moxlib:api/helpers/data/type
-
 data modify storage moxlib:test/it describes set value "Detects short type"
-data modify storage moxlib:test/it expects set value "short"
-data modify storage moxlib:test/it receives set from storage moxlib:api/helpers/data/type output
+
+  data modify storage moxlib:api/helpers/data/type target set value 1s
+  function moxlib:api/helpers/data/type
+
+  data modify storage moxlib:test/it expects set value "short"
+  data modify storage moxlib:test/it receives set from storage moxlib:api/helpers/data/type output
 
 function moxlib:api/test/perform

--- a/data/moxlib/functions/z_spec/helpers/data/type/string.mcfunction
+++ b/data/moxlib/functions/z_spec/helpers/data/type/string.mcfunction
@@ -1,8 +1,9 @@
-data modify storage moxlib:api/helpers/data/type target set value "test"
-function moxlib:api/helpers/data/type
-
 data modify storage moxlib:test/it describes set value "Detects string type"
-data modify storage moxlib:test/it expects set value "string"
-data modify storage moxlib:test/it receives set from storage moxlib:api/helpers/data/type output
+
+  data modify storage moxlib:api/helpers/data/type target set value "test"
+  function moxlib:api/helpers/data/type
+
+  data modify storage moxlib:test/it expects set value "string"
+  data modify storage moxlib:test/it receives set from storage moxlib:api/helpers/data/type output
 
 function moxlib:api/test/perform

--- a/data/moxlib/functions/z_spec/helpers/data/type/unknown.mcfunction
+++ b/data/moxlib/functions/z_spec/helpers/data/type/unknown.mcfunction
@@ -1,8 +1,9 @@
-data modify storage moxlib:api/helpers/data/type target set value {__test:true}
-function moxlib:api/helpers/data/type
-
 data modify storage moxlib:test/it describes set value "Returns unknown if invalid"
-data modify storage moxlib:test/it expects set value "unknown"
-data modify storage moxlib:test/it receives set from storage moxlib:api/helpers/data/type output
+
+  data modify storage moxlib:api/helpers/data/type target set value {__test:true}
+  function moxlib:api/helpers/data/type
+
+  data modify storage moxlib:test/it expects set value "unknown"
+  data modify storage moxlib:test/it receives set from storage moxlib:api/helpers/data/type output
 
 function moxlib:api/test/perform


### PR DESCRIPTION
Refactored units tests to the same format as in Code of Copper.
This puts the name of the test first, then indents everything within the test so it's clear what lines are part of it.